### PR TITLE
Error Message

### DIFF
--- a/b.php
+++ b/b.php
@@ -6,7 +6,9 @@
  */
 
 // Check if GET h is set as it is required.
-if (!isset($_GET['height'])) die();
+if (!isset($_GET['height'])) {
+	die('/* A height parameter is required. */');
+}
 
 $queryString = array();
 foreach ($_GET as $key => $value) {


### PR DESCRIPTION
This is to add an error message that will let the user know that they didn't specify a height if they try to load the b.php file directly without specifying a height.

Better than serving a white page isn't it?
